### PR TITLE
Fix warning and small linting errors

### DIFF
--- a/agegrader/agegrader.py
+++ b/agegrader/agegrader.py
@@ -106,7 +106,7 @@ class AgeGrader(object):
         lower_age = list(item for item in lower_ages if item['age'] == age)
         higher_age = list(item for item in higher_ages if item['age'] == age)
 
-        if len(lower_age) is 0 or len(higher_age) is 0:
+        if len(lower_age) == 0 or len(higher_age) == 0:
             return None
 
         lower_seconds = lower_age[0]['seconds']

--- a/tests/test_agegrader.py
+++ b/tests/test_agegrader.py
@@ -17,7 +17,8 @@ class AgeGraderTestSuite(unittest.TestCase):
         with open('tests/test_data.json') as dat:
             a = AgeGrader(dat)
         agfp = a.age_graded_performance_factor(15, 'M', 5.0, 1234)
-        assert agfp == None
+        assert agfp is None
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Thanks for writing this code, it's working fine in my Python 3.10 app and has saved me a lot of work! 😄 

This PR fixes the following warning I get in my app:
```
/app/agegrader/agegrader/agegrader.py:109: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if len(lower_age) is 0 or len(higher_age) is 0:
```

I've also run flake8 on it and made a couple of small changes it recommended.